### PR TITLE
Implement caching query results

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,14 @@ Simple Cursors
     :member-order: bysource
 
 
+Caching
+-------
+
+.. automodule:: postgres.cache
+    :members:
+    :member-order: bysource
+
+
 An Object-Relational Mapper (ORM)
 ---------------------------------
 
@@ -37,6 +45,8 @@ Changelog
 
 **4.0 (???)**
 
+- implemented caching query results (:pr:`97`)
+- **BREAKING**: the methods :meth:`~postgres.cursors.SimpleCursorBase.one` and :meth:`~postgres.cursors.SimpleCursorBase.all` now have a `max_age` argument; make sure your code doesn't use it as a parameter name
 - dropped support for Python 2.7 and 3.5 (:pr:`96`)
 
 **3.0.0 (Oct 19, 2019)**

--- a/postgres/__init__.py
+++ b/postgres/__init__.py
@@ -173,6 +173,7 @@ from psycopg2.extensions import register_type
 from psycopg2.extras import CompositeCaster
 from psycopg2_pool import ThreadSafeConnectionPool
 
+from postgres.cache import Cache
 from postgres.context_managers import (
     ConnectionContextManager, CursorContextManager, CursorSubcontextManager,
     ConnectionCursorContextManager,
@@ -255,6 +256,7 @@ class Postgres:
         various methods as a :obj:`back_as` argument.
     :param type pool_class: The type of pool to use. Defaults to
         :class:`~psycopg2_pool.ThreadSafeConnectionPool`.
+    :param Cache cache: An instance of :class:`postgres.cache.Cache`.
 
     This is the main object that :mod:`postgres` provides, and you should
     have one instance per process for each PostgreSQL database your process
@@ -304,9 +306,10 @@ class Postgres:
     def __init__(self, url='', minconn=1, maxconn=10, idle_timeout=600,
                  readonly=False, cursor_factory=SimpleNamedTupleCursor,
                  back_as_registry=default_back_as_registry,
-                 pool_class=ThreadSafeConnectionPool):
+                 pool_class=ThreadSafeConnectionPool, cache=None):
 
         self.readonly = readonly
+        self.cache = cache or Cache()
 
         # Set up connection pool.
         # =======================

--- a/postgres/cache.py
+++ b/postgres/cache.py
@@ -1,0 +1,137 @@
+"""
+A query's results can be stored in the :attr:`cache` attribute of the
+:class:`~postgres.Postgres` object to avoid burdening the database with
+redundant requests. The caching is enabled by the `max_age` argument of the
+`one` and `all` methods. For example, this call fetches a row from the `foo`
+table and caches it for 5 seconds:
+
+    >>> db.one("SELECT * FROM foo WHERE bar = 'bit'", max_age=5)
+    Record(bar='bit', baz=537)
+
+Any other thread trying to send the same query while it's still being processed
+waits for the results to be received instead of sending a duplicate query.
+
+The cache key is the query as it's sent to the server, so any difference in the
+parameter values, casing or even whitespace, will result in a cache miss. You
+might need to refactor your code if it sends queries that are similar but not
+exactly identical.
+
+The `max_age` argument doesn't interfere with the `back_as` argument. Moreover,
+the `one` and `all` methods can each use the results cached by the other.
+Consequently, the following call hits the cache if it's executed within 5
+seconds of the previous call above:
+
+    >>> db.all("SELECT * FROM foo WHERE bar = 'bit'", back_as=dict, max_age=5)
+    [{'bar': 'bit', 'baz': 537}]
+
+It's also possible to use different `max_age` values for the same query. If a
+specified `max_age` is greater than the previous one, then the lifetime of the
+cache entry is extended accordingly.
+
+The Cache class
+---------------
+
+"""
+
+from collections import OrderedDict
+from threading import RLock
+from time import perf_counter as time
+
+
+class CacheEntry:
+
+    __slots__ = ('query', 'columns', 'rows', 'max_age', 'lock', 'time')
+
+    def __init__(self, query, max_age, columns, rows):
+        self.query = query
+        self.max_age = max_age
+        self.columns = columns
+        self.rows = rows
+        self.lock = RLock()
+        self.time = time()
+
+
+class Cache:
+    """A cache for rows fetched from a database.
+
+    :arg int max_size: The maximum number of entries allowed in the cache.
+
+    This cache is designed to be thread-safe in CPython and any other Python
+    implementation in which dictionaries (including the :meth:`~dict.setdefault`
+    method) are thread-safe. It uses a different lock for each entry so that
+    unrelated queries don't block each other.
+
+    After inserting a new entry, the oldest one is removed if the cache now has
+    more than `max_size` entries.
+    """
+
+    __slots__ = ('entries', 'max_size')
+
+    def __init__(self, max_size=128):
+        self.entries = OrderedDict()
+        self.max_size = max_size
+
+    def __setitem__(self, key, entry):
+        """Insert an entry into the cache.
+        """
+        self.entries[key] = entry
+        try:
+            self.entries.move_to_end(key)
+        except KeyError:
+            return
+        while len(self.entries) > self.max_size:
+            self.entries.popitem(last=False)
+
+    def clear(self):
+        """Empty the cache. This method isn't used internally.
+        """
+        self.entries.clear()
+
+    def get_lock(self, key):
+        """Get the lock object for the specified key.
+        """
+        temporary_entry = CacheEntry(key, 60, None, None)
+        return self.entries.setdefault(key, temporary_entry).lock
+
+    def lookup(self, key, max_age):
+        """Look up a cache entry and check its age.
+
+        This function returns :obj:`None` if there isn't an entry in the cache
+        for the specified key or if the entry is older than `max_age`.
+        """
+        entry = self.entries.get(key)
+        if entry is None or entry.rows is None:
+            return
+        now = time()
+        if entry.time < (now - entry.max_age):
+            if entry and entry.time >= (now - max_age):
+                # Extend the lifetime of the entry.
+                entry.max_age = max_age
+            else:
+                # Don't attempt to drop the entry, just return.
+                return
+        return entry
+
+    def pop_entry(self, entry, blocking=True):
+        """Remove the specified entry from the cache.
+
+        If `blocking` is `False`, then the entry will only be removed if its
+        lock isn't currently held by another thread.
+        """
+        if entry.lock.acquire(blocking=blocking):
+            try:
+                popped_entry = self.entries.pop(entry.query, None)
+                if popped_entry is not None and popped_entry is not entry:
+                    # We popped a different entry inserted by another thread,
+                    # put it back in.
+                    self.entries[popped_entry.query] = popped_entry
+            finally:
+                entry.lock.release()
+
+    def prune(self):
+        """Drop stale entries from the cache. This method isn't used internally.
+        """
+        for key, entry in list(self.entries.items()):
+            if entry.time >= (time() - entry.max_age):
+                continue
+            self.pop_entry(entry, blocking=False)


### PR DESCRIPTION
This is meant to advantageously replace the [`query_cache` module](https://github.com/liberapay/liberapay.com/blob/78c5eb910877e936b91d1dae274b8cf1f82f3191/liberapay/utils/query_cache.py) that @chadwhitacre wrote more than a decade ago (according to the Git history).